### PR TITLE
Add populate information method 

### DIFF
--- a/lib/item.rb
+++ b/lib/item.rb
@@ -1,3 +1,4 @@
+require 'bigdecimal'
 class Item
   attr_reader :id,
               :name,
@@ -15,7 +16,7 @@ class Item
     @updated_at = item_info[:updated_at]
     @merchant_id = item_info[:merchant_id]
   end
-  def unit_price_to_dollars
-    @unit_price.to_f
-  end
+  # def unit_price_to_dollars
+  #   @unit_price.to_f
+  # end
 end

--- a/lib/item_repository.rb
+++ b/lib/item_repository.rb
@@ -4,11 +4,29 @@ require 'time'
 
 class ItemRepo
 
+  attr_reader :items
+  def initialize 
+    @items = []
+  end
+
   def populate_information
     items = Hash.new{|h, k| h[k] = [] }
     CSV.foreach('./data/items.csv', headers: true, header_converters: :symbol) do |item_info|
       items[item_info[:id]] = Item.new(item_info)
     end
       items
+  end
+
+  def all 
+    #returns array of all known item instances
+   @items = populate_information.map do |item|
+      item[1]
+    end
+  end
+
+  def find_by_id(id)
+    populate_information.select do |item|
+      item[id] == id
+    end
   end
 end

--- a/lib/item_repository.rb
+++ b/lib/item_repository.rb
@@ -1,0 +1,14 @@
+require 'bigdecimal'
+require 'CSV'
+require 'time'
+
+class ItemRepo
+
+  def populate_information
+    items = Hash.new{|h, k| h[k] = [] }
+    CSV.foreach('./data/items.csv', headers: true, header_converters: :symbol) do |item_info|
+      items[item_info[:id]] = Item.new(item_info)
+    end
+      items
+  end
+end

--- a/spec/item_repository_spec.rb
+++ b/spec/item_repository_spec.rb
@@ -1,0 +1,52 @@
+require 'CSV'
+require 'RSpec'
+require './lib/sales_engine'
+require './lib/item'
+require './lib/item_repository'
+require 'bigdecimal'
+# require './data/merchants.csv'
+
+RSpec.describe ItemRepo do
+  describe 'instantiation' do
+
+    it '::new' do
+      ir = ItemRepo.new
+
+    expect(ir).to be_an_instance_of(ItemRepo)
+    end
+
+    it 'has attributes' do
+      ir = ItemRepo.new
+  
+      i = Item.new({:id          => 1,
+                    :name        => "Pencil",
+                    :description => "You can use it to write things",
+                    :unit_price  => BigDecimal(10.99,4),
+                    :created_at  => Time.now,
+                    :updated_at  => Time.now,
+                    :merchant_id => 2})
+
+      expect(i.id).to eq(1)
+      expect(i.name).to eq("Pencil")
+      expect(i.description).to eq("You can use it to write things")
+      expect(i.unit_price).to be_an_instance_of(BigDecimal)
+      expect(i.created_at).to be_an_instance_of(Time)
+      expect(i.updated_at).to be_an_instance_of(Time)
+    end
+  end
+
+  describe '#methods' do
+    it '#populates information' do
+      ir = ItemRepo.new
+      i = Item.new({:id          => 1,
+                    :name        => "Pencil",
+                    :description => "You can use it to write things",
+                    :unit_price  => BigDecimal(10.99,4),
+                    :created_at  => Time.now,
+                    :updated_at  => Time.now,
+                    :merchant_id => 2})
+    require 'pry'; binding.pry
+      expect(ir.populate_information).to be_an_instance_of(Hash)
+    end
+  end
+end

--- a/spec/item_repository_spec.rb
+++ b/spec/item_repository_spec.rb
@@ -18,25 +18,24 @@ RSpec.describe ItemRepo do
     it 'has attributes' do
       ir = ItemRepo.new
   
-      i = Item.new({:id          => 1,
-                    :name        => "Pencil",
-                    :description => "You can use it to write things",
-                    :unit_price  => BigDecimal(10.99,4),
-                    :created_at  => Time.now,
-                    :updated_at  => Time.now,
-                    :merchant_id => 2})
-
-      expect(i.id).to eq(1)
-      expect(i.name).to eq("Pencil")
-      expect(i.description).to eq("You can use it to write things")
-      expect(i.unit_price).to be_an_instance_of(BigDecimal)
-      expect(i.created_at).to be_an_instance_of(Time)
-      expect(i.updated_at).to be_an_instance_of(Time)
+      expect(ir.items).to eq ([])
     end
   end
 
   describe '#methods' do
     it '#populates information' do
+      ir = ItemRepo.new
+
+      expect(ir.populate_information).to be_an_instance_of(Hash)
+    end
+
+    it '#all' do
+      ir = ItemRepo.new
+
+      expect(ir.all).to be_an_instance_of(Array)
+    end
+
+    it '#find by id' do
       ir = ItemRepo.new
       i = Item.new({:id          => 1,
                     :name        => "Pencil",
@@ -44,9 +43,12 @@ RSpec.describe ItemRepo do
                     :unit_price  => BigDecimal(10.99,4),
                     :created_at  => Time.now,
                     :updated_at  => Time.now,
-                    :merchant_id => 2})
-    require 'pry'; binding.pry
-      expect(ir.populate_information).to be_an_instance_of(Hash)
+                    :merchant_id => 2
+                  })
+      id = "263395237"
+      ir.items << i 
+
+      expect(ir.find_by_id(id)).to eq(i)
     end
   end
 end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -1,0 +1,37 @@
+require 'RSpec'
+require './lib/item'
+require 'bigdecimal'
+
+RSpec.describe Item do
+  describe 'instantiation' do
+    it '::new' do
+      i = Item.new({:id          => 1,
+                    :name        => "Pencil",
+                    :description => "You can use it to write things",
+                    :unit_price  => BigDecimal.new(10.99,4),
+                    :created_at  => Time.now,
+                    :updated_at  => Time.now,
+                    :merchant_id => 2
+                  })
+      expect(i).to be_an_instance_of(Item)
+    end
+
+    it 'has attributes' do
+      i = Item.new({:id          => 1,
+      :name        => "Pencil",
+      :description => "You can use it to write things",
+      :unit_price  => BigDecimal(10.99,4),
+      :created_at  => Time.now,
+      :updated_at  => Time.now,
+      :merchant_id => 2})
+      
+      expect(i.id).to eq(1)
+      expect(i.name).to eq("Pencil")
+      expect(i.description).to eq("You can use it to write things")
+      expect(i.unit_price).to be_an_instance_of(BigDecimal)
+      expect(i.created_at).to be_an_instance_of(Time)
+      expect(i.updated_at).to be_an_instance_of(Time)
+    end
+  end
+end
+

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe Item do
 
     it 'has attributes' do
       i = Item.new({:id          => 1,
-      :name        => "Pencil",
-      :description => "You can use it to write things",
-      :unit_price  => BigDecimal(10.99,4),
-      :created_at  => Time.now,
-      :updated_at  => Time.now,
-      :merchant_id => 2})
+                    :name        => "Pencil",
+                    :description => "You can use it to write things",
+                    :unit_price  => BigDecimal(10.99,4),
+                    :created_at  => Time.now,
+                    :updated_at  => Time.now,
+                    :merchant_id => 2})
       
       expect(i.id).to eq(1)
       expect(i.name).to eq("Pencil")


### PR DESCRIPTION
What this changes:
 
Item Spec - Adds tests for item attributes 
Item Repo - Adds populate_information method and tests
Item Repo Spec - Add populate_information spec

Questions: 
I'm not sure if we're supposed to include `require 'bigdecimal'` in every file. I was having serious trouble getting it to run. 

To Review: 
Item spec for format and content
Item Repo spec for format and content
 - all method test 
 - find_by_id(id) test: this one is definitely messy... 
