### PR TITLE
Update arguments for item and merchant

### DIFF
--- a/lib/item_repo.rb
+++ b/lib/item_repo.rb
@@ -13,7 +13,7 @@ class ItemRepo
 
   def populate_information(path)
     CSV.foreach(path, headers: true, header_converters: :symbol) do |item_info|
-      @items << Item.new(item_info, @engine)
+      @items << Item.new(item_info, self)
     end
   end
 

--- a/lib/merchant.rb
+++ b/lib/merchant.rb
@@ -1,9 +1,11 @@
 class Merchant
   attr_accessor :id,
-                :name
+                :name,
+                :repo
 
-  def initialize(merchant_info, engine)
+  def initialize(merchant_info, repo)
     @id = merchant_info[:id].to_i
     @name = merchant_info[:name]
+    @repo = repo
   end
 end

--- a/lib/merchant_repo.rb
+++ b/lib/merchant_repo.rb
@@ -13,7 +13,7 @@ class MerchantRepo
 
   def populate_information(path)
     CSV.foreach(path, headers: true, header_converters: :symbol) do |merchant_info|
-      @merchants << Merchant.new(merchant_info, @engine)
+      @merchants << Merchant.new(merchant_info, self)
     end
   end
 


### PR DESCRIPTION
Hey everyone, this PR changes the `engine` argument into `self` in the in the Item/ItemRepo and Merchant/MerchantRepo classes. When each thing is initialized, it should be inheriting the repo itself. 

Questions:
none so far

To Review:
Let me know if the item/merchant instances are still having trouble accessing the repo