### PR TITLE
Migrate update method

### DIFF
--- a/lib/invoice.rb
+++ b/lib/invoice.rb
@@ -16,4 +16,17 @@ class Invoice
     @created_at = Time.parse(invoice_info[:created_at].to_s)
     @updated_at = Time.parse(invoice_info[:updated_at].to_s)
   end
+
+  def update_all(attributes)
+    update_status(attributes)
+    update_updated_at(attributes)
+  end
+
+  def update_status(attributes)
+    @status = attributes[:status] if attributes[:status]
+  end
+
+  def update_updated_at(attributes)
+    @updated_at = attributes[:updated_at] if attributes[:updated_at]
+  end
 end

--- a/lib/invoice_repo.rb
+++ b/lib/invoice_repo.rb
@@ -60,11 +60,9 @@ class InvoiceRepo
   end
 
   def update(id, attributes)
-    new_invoice = find_by_id(id)
-    return if !new_invoice
-    new_invoice.status = attributes[:status]
-    new_invoice.updated_at = Time.now
-    new_invoice
+    invoice = find_by_id(id)
+    return if !invoice
+    invoice.update_all(attributes)
   end
 
   def delete(id)

--- a/lib/item.rb
+++ b/lib/item.rb
@@ -22,4 +22,27 @@ class Item
   def unit_price_to_dollars
     @unit_price.to_f
   end
+
+  def update_all(attributes)
+    update_name(attributes)
+    update_description(attributes)
+    update_unit_price(attributes)
+    update_updated_at(attributes)
+  end
+
+  def update_name(attributes)
+    @name = attributes[:name] if attributes[:name]
+  end
+
+  def update_description(attributes)
+    @description = attributes[:description] if attributes[:description]
+  end
+
+  def update_unit_price(attributes)
+    @unit_price = attributes[:unit_price] if attributes[:unit_price]
+  end
+
+  def update_updated_at(attributes)
+    @updated_at = attributes[:updated_at] if attributes[:updated_at]
+  end
 end

--- a/lib/item_repo.rb
+++ b/lib/item_repo.rb
@@ -72,21 +72,15 @@ class ItemRepo
     item
   end
 
-  # the code logic doesn't belong here, what happens when only one gets updated
   def update(id, attributes)
-    new_item = find_by_id(id)
-    return if !new_item
-    new_item.name = attributes[:name] if  attributes[:name]
-    new_item.description = attributes[:description] if attributes[:description]
-    new_item.unit_price = attributes[:unit_price] if attributes[:unit_price]
-    new_item.updated_at = Time.now
-    new_item
+    item = find_by_id(id)
+    return if !item
+    item.update_all(attributes)
   end
 
   def delete(id)
     @items.delete(find_by_id(id))
   end
-
 
   def average_price #Needs spec
     price_total = @items.sum do |item|

--- a/lib/merchant.rb
+++ b/lib/merchant.rb
@@ -9,6 +9,5 @@ class Merchant
 
   def update_name(attributes)
     @name = attributes[:name]
-    require 'pry'; binding.pry
   end
 end

--- a/lib/merchant.rb
+++ b/lib/merchant.rb
@@ -6,4 +6,9 @@ class Merchant
     @id = merchant_info[:id].to_i
     @name = merchant_info[:name]
   end
+
+  def update_name(attributes)
+    @name = attributes[:name]
+    require 'pry'; binding.pry
+  end
 end

--- a/lib/merchant_repo.rb
+++ b/lib/merchant_repo.rb
@@ -52,10 +52,9 @@ class MerchantRepo
   end
 
   def update(id, attributes)
-    new_merchant = find_by_id(id)
-    return if !new_merchant
-    new_merchant.name = attributes[:name]
-    new_merchant
+    merchant = find_by_id(id)
+    return if !merchant
+    merchant.update_name(attributes)
   end
 
   def delete(id)

--- a/spec/invoice_repo_spec.rb
+++ b/spec/invoice_repo_spec.rb
@@ -137,6 +137,7 @@ RSpec.describe InvoiceRepo do
       invoice_repo.update(invoice.id, {:status => 'shipped'})
 
       expect(invoice.status).to eq('shipped')
+      expect(invoice.updated_at).to be_an_instance_of(Time)
     end
 
     it '#delete' do

--- a/spec/invoice_spec.rb
+++ b/spec/invoice_spec.rb
@@ -29,4 +29,31 @@ RSpec.describe Invoice do
       expect(invoice.updated_at).to be_an_instance_of(Time)
     end
   end
+
+  describe '#methods' do
+    it '#updates status' do
+      invoice = Invoice.new({:id => 6,
+                            :customer_id => 7,
+                            :merchant_id => 8,
+                            :status => 'pending',
+                            :created_at => Time.now,
+                            :updated_at => Time.now})  
+
+      invoice.update_status({:status => :shipped})
+      expect(invoice.status).to eq(:shipped)
+    end
+
+    it '#updates updated at time' do
+    invoice = Invoice.new({:id => 6,
+                           :customer_id => 7,
+                           :merchant_id => 8,
+                           :status => 'pending',
+                           :created_at => Time.now,
+                           :updated_at => Time.now})
+  
+    invoice.update_updated_at({:updated_at => Time.now})
+  
+    expect(invoice.updated_at).to be_an_instance_of(Time)
+  end
+  end
 end

--- a/spec/item_repo_spec.rb
+++ b/spec/item_repo_spec.rb
@@ -159,19 +159,18 @@ RSpec.describe ItemRepo do
    it '#delete by id' do
     item_repo = @sales_engine.items
     item = item_repo.create({:id        => 1,
-                           :name        => "Pencil",
-                           :description => "You can use it to write things",
-                           :unit_price  => 1099,
-                           :created_at  => Time.now,
-                           :updated_at  => Time.now,
-                           :merchant_id => 2})
+                             :name        => "Pencil",
+                             :description => "You can use it to write things",
+                             :unit_price  => 1099,
+                             :created_at  => Time.now,
+                             :updated_at  => Time.now,
+                             :merchant_id => 2})
 
       expect(item_repo.find_by_id(item.id)).to eq(item)
 
       item_repo.delete(item.id)
 
       expect(item_repo.find_by_id(item.id)).to eq(nil)
-
     end
 
     it '#item merchant count' do

--- a/spec/item_repo_spec.rb
+++ b/spec/item_repo_spec.rb
@@ -4,12 +4,12 @@ require 'sales_engine'
 
 RSpec.describe ItemRepo do
   before(:each) do
-    @sales_engine = SalesEngine.from_csv({:items => './data/items.csv',
-                                          :merchants => './data/merchants.csv',
-                                          :invoices => './data/invoices.csv',
-                                          :invoice_items => './data/invoice_items.csv',
-                                          :transactions  => './data/transactions.csv',
-                                          :customers => './data/customers.csv'
+    @sales_engine = SalesEngine.from_csv({:items => './data/mock_items.csv',
+                                          :merchants => './data/mock_merchants.csv',
+                                          :invoices => './data/mock_invoices.csv',
+                                          :invoice_items => './data/mock_invoice_items.csv',
+                                          :transactions  => './data/mock_transactions.csv',
+                                          :customers => './data/mock_customers.csv'
                                         })
   end
 

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -1,12 +1,12 @@
-require './lib/item'
+require 'item'
 require 'bigdecimal'
 
 RSpec.describe Item do
   describe 'instantiation' do
     it '::new' do
       item1 = Item.new({:id          => 1,
-                        :name        => "Pencil",
-                        :description => "You can use it to write things",
+                        :name        => 'Pencil',
+                        :description => 'You can use it to write things',
                         :unit_price  => BigDecimal(10.99,4),
                         :created_at  => Time.now,
                         :updated_at  => Time.now,
@@ -17,16 +17,16 @@ RSpec.describe Item do
 
     it 'has attributes' do
       item1 = Item.new({:id          => 1,
-                        :name        => "Pencil",
-                        :description => "You can use it to write things",
+                        :name        => 'Pencil',
+                        :description => 'You can use it to write things',
                         :unit_price  => BigDecimal(10.99,4),
                         :created_at  => Time.now,
                         :updated_at  => Time.now,
                         :merchant_id => 2})
       
       expect(item1.id).to eq(1)
-      expect(item1.name).to eq("Pencil")
-      expect(item1.description).to eq("You can use it to write things")
+      expect(item1.name).to eq ('Pencil')
+      expect(item1.description).to eq('You can use it to write things')
       expect(item1.unit_price).to be_an_instance_of(BigDecimal)
       expect(item1.created_at).to be_an_instance_of(Time)
       expect(item1.updated_at).to be_an_instance_of(Time)
@@ -35,15 +35,107 @@ RSpec.describe Item do
 
   describe '#methods' do
     it '#unit price to dollars' do
-      item = Item.new({:id          => 1,
-                        :name        => "Pencil",
-                        :description => "You can use it to write things",
+      item = Item.new({:id           => 1,
+                        :name        => 'Pencil',
+                        :description => 'You can use it to write things',
                         :unit_price  => 1099,
                         :created_at  => Time.now,
                         :updated_at  => Time.now,
                         :merchant_id => 2})
     
       expect(item.unit_price_to_dollars).to eq(10.99)
+    end
+
+    it '#updates name if new name' do
+      item = Item.new({:id          => 1,
+                       :name        => 'Pencil',
+                       :description => 'You can use it to write things',
+                       :unit_price  => 1099,
+                       :created_at  => Time.now,
+                       :updated_at  => Time.now,
+                       :merchant_id => 2})  
+     
+      item.update_name({:name => 'Knife'})
+     
+      expect(item.name).to eq('Knife')
+
+      item = Item.new({:id          => 1,
+                       :name        => 'Pencil',
+                       :description => 'You can use it to write things',
+                       :unit_price  => 1099,
+                       :created_at  => Time.now,
+                       :updated_at  => Time.now,
+                       :merchant_id => 2}) 
+
+      item.update_name({:id => 1})
+
+      expect(item.name).to eq('Pencil')
+    end
+
+    it '#updates description if new description' do
+      item = Item.new({:id          => 1,
+                        :name        => 'Pencil',
+                        :description => 'You can use it to write things',
+                        :unit_price  => 1099,
+                        :created_at  => Time.now,
+                        :updated_at  => Time.now,
+                        :merchant_id => 2})  
+    
+      item.update_description({:description => 'You can use it to stab things'})
+    
+      expect(item.description).to eq('You can use it to stab things')
+
+      item2 = Item.new({:id          => 1,
+                        :name        => 'Pencil',
+                        :description => 'You can use it to write things',
+                        :unit_price  => 1099,
+                        :created_at  => Time.now,
+                        :updated_at  => Time.now,
+                        :merchant_id => 2}) 
+
+      item2.update_description({:id => 1})
+
+      expect(item2.name).to eq('Pencil')
+    end
+
+    it '#updates unit price if new unit price' do
+      item = Item.new({:id          => 1,
+                       :name        => 'Pencil',
+                       :description => 'You can use it to write things',
+                       :unit_price  => 1099,
+                       :created_at  => Time.now,
+                       :updated_at  => Time.now,
+                       :merchant_id => 2})  
+      
+      item.update_unit_price({:unit_price => BigDecimal(15.99, 4)})
+    
+      expect(item.unit_price).to eq(15.99)
+
+      item2 = Item.new({:id          => 1,
+                        :name        => 'Pencil',
+                        :description => 'You can use it to write things',
+                        :unit_price  => 1099,
+                        :created_at  => Time.now,
+                        :updated_at  => Time.now,
+                        :merchant_id => 2}) 
+
+      item2.update_unit_price({:id => 1})
+
+      expect(item2.unit_price).to eq(10.99)
+    end
+
+    it '#updates updated at time' do
+      item = Item.new({:id          => 1,
+                      :name        => 'Pencil',
+                      :description => 'You can use it to write things',
+                      :unit_price  => 1099,
+                      :created_at  => Time.now,
+                      :updated_at  => Time.now,
+                      :merchant_id => 2})  
+    
+      item.update_updated_at({:updated_at => Time.now})
+    
+      expect(item.updated_at).to be_an_instance_of(Time)
     end
   end
 end

--- a/spec/merchant_spec.rb
+++ b/spec/merchant_spec.rb
@@ -5,16 +5,25 @@ RSpec.describe Merchant do
   describe 'instantiation' do
     
     it '::new' do
-      merchant1 = Merchant.new({:id => 5, :name => "Turing School"})
+      merchant = Merchant.new({:id => 5, :name => 'Turing School'})
 
-    expect(merchant1).to be_an_instance_of(Merchant)
+    expect(merchant).to be_an_instance_of(Merchant)
     end
 
     it 'has attributes' do
-      merchant1 = Merchant.new({:id => 5, :name => "Turing School"})
+      merchant = Merchant.new({:id => 5, :name => 'Turing School'})
 
-      expect(merchant1.id).to eq(5)
-      expect(merchant1.name).to eq("Turing School")
+      expect(merchant.id).to eq(5)
+      expect(merchant.name).to eq('Turing School')
+    end
+  end
+
+  describe '#methods' do
+    it '#update name' do
+      merchant = Merchant.new({:id => 5, :name => 'Turing School'}) 
+      merchant.update_name({:name => 'George Washington University'})
+      
+      expect(merchant.name).to eq('George Washington University')
     end
   end
 end


### PR DESCRIPTION
Hey everyone, this PR migrates the `update` method from `invoice_repo`, `item_repo` and `merchant_repo` to its respective classes. You'll see the changes reflected in the class files and specs of each. 

Questions: 
- Do you want me to go ahead and migrate the other methods as well? 
- What else is needed to make sure the module works smoothly?

To Review: 
- Any inconsistencies? 